### PR TITLE
test: add regression for optical SFP/QSFP OOM (#45)

### DIFF
--- a/tests/unit/parser_error_handling.rs
+++ b/tests/unit/parser_error_handling.rs
@@ -162,6 +162,45 @@ fn test_unknown_agent_address() {
 }
 
 #[test]
+fn test_optical_sfp_qsfp_oom_regression() {
+    // Regression test for https://github.com/nxthdr/sflow-parser/issues/45
+    //
+    // This 114-byte datagram declares an expanded counters sample whose optical
+    // SFP/QSFP record (format 0,10) advertises num_lanes = 0x23600800
+    // (593,496,064). With a 40-byte `Lane`, an unbounded `Vec::with_capacity`
+    // would attempt to reserve 593_496_064 * 40 = 23,739,842,560 bytes (~22 GiB)
+    // and OOM-kill the process before reading a single lane.
+    //
+    // The parser must instead reject the datagram (the record's opaque data is
+    // far too short to hold that many lanes) without attempting a giant
+    // allocation. This must complete near-instantly with negligible memory.
+    let data: [u8; 114] = [
+        0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, // version=5, addr type=unknown
+        0x06, 0x23, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, // sub_agent_id, sequence_number
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // uptime, num_samples=3
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+        0x4f, // sample type=4 (counters expanded), len=79
+        0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, // seq, source_id_type
+        0x4f, 0x4f, 0x4f, 0x4f, 0x00, 0x00, 0x00, 0x05, // source_id_index, num_records=5
+        0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x27, // counter format=10 (optical), len=39
+        0x00, 0x24, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, // module_id, module_num_lanes
+        0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+        0x04, // module_supply_voltage, module_temperature
+        0x23, 0x60, 0x08, 0x00, 0x00, 0xf9, 0xff,
+        0x00, // num_lanes=0x23600800 (~22 GiB if unbounded)
+        0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, //
+        0x4f, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x23, 0x28, //
+        0x0d, 0xf3, 0x26, 0x00, 0x62, 0x01, 0x00, 0x00, //
+        0x00, 0x00,
+    ];
+
+    // Must return Err (truncated lane array) rather than OOM.
+    let result = parse_datagram(&data);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_unknown_header_protocol() {
     // Test that HeaderProtocol::from_u32 rejects invalid values
     use sflow_parser::models::record_flows::HeaderProtocol;


### PR DESCRIPTION
## Summary

Adds a regression test for #45 — a malformed 114-byte sFlow v5 datagram that drove a ~22 GiB allocation in `parse_optical_sfp_qsfp`.

The optical SFP/QSFP counter record (format `0,10`) reads `num_lanes = 0x23600800` (593,496,064). On `0.6.0` this sized an unbounded `Vec::with_capacity(593_496_064)` × `size_of::<Lane>()` (40 bytes) = **23,739,842,560 bytes** — exactly the `malloc(23739842560)` in the issue backtrace — OOM-killing the process before a single lane was read.

## Why a test, not a code fix

The allocation cap added in `8d23733` ("fix OOM found with fuzz testing", after the `v0.6.0` tag) already mitigates this: capacity is clamped to `.min(1024)` and the read loop hits EOF on the truncated record, so `parse_datagram` now returns `Err`. An audit of every `with_capacity` / `vec![0u8; n]` in the crate confirms all count-prefixed allocations are capped and `read_opaque` caps at 100 MB — no remaining amplification vector.

This PR pins that behaviour with `test_optical_sfp_qsfp_oom_regression`, which feeds the exact reproducer and asserts `Err` (completes in ~0.00s with negligible memory).

> Note: the issue also suggested adding the input to the fuzz corpus. `tests/fuzz/.gitignore` excludes `corpus/`, so the seed is kept locally only; this tracked unit test is the persisted regression guard.

## Verification

- `cargo test` — 255 + 1 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build` — all clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)